### PR TITLE
[feat] Add genereralized useGet hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install --save use-fauna
 - `useUpdateDocument`
 - `useDeleteDocument`
 - `useGetAll`
+- `useGet`
 
 ---
 

--- a/example/src/Content.tsx
+++ b/example/src/Content.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import faunadb from 'faunadb'
 
-import { useFaunaClient, useGetAll } from 'use-fauna'
+import { useFaunaClient, useGetAll, useGet } from 'use-fauna'
 import { DataItem } from '../../src/types/fauna'
 
 function Content() {
@@ -15,10 +15,16 @@ function Content() {
   console.log('status', status)
 
   // useGet
-  // const x = useGet()
+  const [getFunction, getData, getStatus] = useGet(client)
+  const [getSchema, setGetSchema] = useState('collection')
+  const [getRefId, setGetRefId] = useState('')
+  console.log('getFunction', getFunction)
+  console.log('getData', getData)
+  console.log('getStatus', getStatus)
 
   return (
     <div>
+      {/* useGetAll */}
       <div>
         <p>Get all of a schema type</p>
         <select
@@ -63,6 +69,36 @@ function Content() {
           data.map((item: DataItem) => {
             return <p>{`${item.ref}`}</p>
           })}
+      </div>
+
+      <hr />
+
+      {/* useGet */}
+      <div>
+        <input type="getRef" value={getRefId} onChange={e => setGetRefId(e.target.value)} />
+        <select
+          name="getSchema"
+          id="getSchema"
+          value={getSchema}
+          onChange={e => {
+            setGetSchema(e.target.value)
+          }}
+          defaultValue={0}
+        >
+          <option value="collection">collection</option>
+          <option value="database">database</option>
+          <option value="document">document</option>
+          <option value="function">function</option>
+          <option value="index">index</option>
+        </select>
+        <button
+          onClick={e => {
+            e.preventDefault()
+            getFunction(getSchema, getRefId)
+          }}
+        >
+          Get
+        </button>
       </div>
     </div>
   )

--- a/example/src/Content.tsx
+++ b/example/src/Content.tsx
@@ -120,6 +120,11 @@ function Content() {
         >
           Get
         </button>
+        {getData && (
+          <div>
+            <code>{JSON.stringify(getData)}</code>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/example/src/Content.tsx
+++ b/example/src/Content.tsx
@@ -2,15 +2,7 @@ import React, { useState } from 'react'
 import faunadb from 'faunadb'
 
 import { useFaunaClient, useGetAll } from 'use-fauna'
-import {
-  Collection,
-  Database,
-  Document,
-  Function as FaunaFunction,
-  Index
-} from '../../src/types/fauna'
-
-type DataItem = Collection | Database | Document | FaunaFunction | Index
+import { DataItem } from '../../src/types/fauna'
 
 function Content() {
   const client: faunadb.Client = useFaunaClient(process.env.REACT_APP_FAUNA_KEY as string)
@@ -21,6 +13,9 @@ function Content() {
   const [getAll, data = null, status] = useGetAll(client)
   console.log('data', data)
   console.log('status', status)
+
+  // useGet
+  // const x = useGet()
 
   return (
     <div>

--- a/example/src/Content.tsx
+++ b/example/src/Content.tsx
@@ -18,6 +18,7 @@ function Content() {
   const [getFunction, getData, getStatus] = useGet(client)
   const [getSchema, setGetSchema] = useState('collection')
   const [getRefId, setGetRefId] = useState('')
+  const [useGetRefId, setUseGetRefId] = useState('')
   console.log('getFunction', getFunction)
   console.log('getData', getData)
   console.log('getStatus', getStatus)
@@ -75,7 +76,27 @@ function Content() {
 
       {/* useGet */}
       <div>
-        <input type="getRef" value={getRefId} onChange={e => setGetRefId(e.target.value)} />
+        <div>
+          <label htmlFor="getRef">
+            {getSchema !== 'document' ? `${getSchema}` : 'collection'} name
+          </label>
+          <input
+            id="getRef"
+            type="getRef"
+            value={getRefId}
+            onChange={e => setGetRefId(e.target.value)}
+          />
+          {getSchema === 'document' && (
+            <>
+              <label htmlFor="useGetRefId">Document RefId</label>
+              <input
+                id="useGetRefId"
+                value={useGetRefId}
+                onChange={e => setUseGetRefId(e.target.value)}
+              />
+            </>
+          )}
+        </div>
         <select
           name="getSchema"
           id="getSchema"
@@ -94,7 +115,7 @@ function Content() {
         <button
           onClick={e => {
             e.preventDefault()
-            getFunction(getSchema, getRefId)
+            getFunction(getSchema, getRefId, useGetRefId)
           }}
         >
           Get

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,10 +5,19 @@ export const FaunaStatus = {
   ERROR: 'error'
 }
 
+// TODO: Refactor this name to be more semantic
 export const FaunaSchemas = {
   Collections: 'collections',
   Databases: 'databases',
   Documents: 'documents',
   Functions: 'functions',
   Indexes: 'indexes'
+}
+
+export const FaunaSchema = {
+  Collection: 'collection',
+  Database: 'database',
+  Document: 'document',
+  Function: 'function',
+  Index: 'index'
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import useDeleteDocument from './useDeleteDocument'
 import useUpdateDocument from './useUpdateDocument'
 import useFaunaClient from './useFaunaClient'
 import useGetAll from './useGetAll'
+import useGet from './useGet'
 
 // export { useDatabase }
 export { useGetDocument }
@@ -13,3 +14,4 @@ export { useDeleteDocument }
 export { useUpdateDocument }
 export { useFaunaClient }
 export { useGetAll }
+export { useGet }

--- a/src/types/fauna.ts
+++ b/src/types/fauna.ts
@@ -42,3 +42,5 @@ export interface Index {
   ts: number
   unique: boolean
 }
+
+export type DataItem = Collection | Database | Document | Function | Index

--- a/src/useGet.test.ts
+++ b/src/useGet.test.ts
@@ -1,0 +1,100 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import faunadb from 'faunadb'
+
+import { FaunaStatus } from './constants'
+
+import useFaunaClient from './useFaunaClient'
+import useGet from './useGet'
+
+describe('useGet', () => {
+  it('successfully retrieves non-Document schemas', () => {
+    // Instantiate client
+    const { result: db } = renderHook(() =>
+      useFaunaClient('fnADxo6lvWACEnAmge1HiGgF9FmI48Ok75ij_Yfk')
+    )
+    const client = db.current
+    expect(client).toBeInstanceOf(faunadb.Client)
+
+    // Render useGet
+    const { result, waitForNextUpdate } = renderHook(() => useGet(client))
+    const getFunction = result.current[0]
+    const getData = result.current[1]
+    const getStatus = result.current[2]
+
+    expect(getFunction).toBeInstanceOf(Function)
+    expect(getData).toBeNull()
+    expect(getStatus).toBe(FaunaStatus.NOT_LOADED)
+
+    act(async () => {
+      getFunction('collection', 'orders')
+
+      await waitForNextUpdate()
+      expect(getData).toBeNull()
+      expect(getStatus).toEqual(FaunaStatus.LOADING)
+
+      await waitForNextUpdate()
+      expect(getStatus).toEqual(FaunaStatus.LOADED)
+      expect(getData).toBeDefined()
+      expect(getData).toBeInstanceOf(Object)
+    })
+  })
+
+  it('successfully retrieves Document', () => {
+    // Instantiate client
+    const { result: db } = renderHook(() =>
+      useFaunaClient('fnADxo6lvWACEnAmge1HiGgF9FmI48Ok75ij_Yfk')
+    )
+    const client = db.current
+    expect(client).toBeInstanceOf(faunadb.Client)
+
+    // Render useGet
+    const { result, waitForNextUpdate } = renderHook(() => useGet(client))
+    const getFunction = result.current[0]
+    const getData = result.current[1]
+    const getStatus = result.current[2]
+
+    expect(getFunction).toBeInstanceOf(Function)
+    expect(getData).toBeNull()
+    expect(getStatus).toBe(FaunaStatus.NOT_LOADED)
+
+    act(async () => {
+      getFunction('document', 'orders', '269603026111563282')
+
+      await waitForNextUpdate()
+      expect(getData).toBeNull()
+      expect(getStatus).toEqual(FaunaStatus.LOADING)
+
+      await waitForNextUpdate()
+      expect(getStatus).toEqual(FaunaStatus.LOADED)
+      expect(getData).toBeDefined()
+      expect(getData).toBeInstanceOf(Object)
+    })
+  })
+
+  it('fails to retrieve schema', () => {
+    // Instantiate client
+    const { result: db } = renderHook(() =>
+      useFaunaClient('fnADxo6lvWACEnAmge1HiGgF9FmI48Ok75ij_Yfk')
+    )
+    const client = db.current
+    expect(client).toBeInstanceOf(faunadb.Client)
+
+    // Render useGet
+    const { result, waitForNextUpdate } = renderHook(() => useGet(client))
+    const getFunction = result.current[0]
+    const getData = result.current[1]
+    const getStatus = result.current[2]
+
+    expect(getFunction).toBeInstanceOf(Function)
+    expect(getData).toBeNull()
+    expect(getStatus).toBe(FaunaStatus.NOT_LOADED)
+
+    act(async () => {
+      getFunction('collection', 'hamburgers')
+
+      await waitForNextUpdate()
+      expect(getData).toBeNull()
+      expect(getStatus).toEqual(FaunaStatus.ERROR)
+    })
+  })
+})

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -1,0 +1,14 @@
+import { useState, useCallback } from 'react'
+import faunadb from 'faunadb'
+
+import { DataItem } from './types/fauna'
+import { FaunaStatus } from './constants'
+
+export default function useGet(client: faunadb.Client): [Function, null | DataItem, string] {
+  console.log(client)
+  const [data] = useState(null)
+  const [status] = useState(FaunaStatus.NOT_LOADED)
+  const get = useCallback(() => {}, [])
+
+  return [get, data, status]
+}

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -1,14 +1,53 @@
 import { useState, useCallback } from 'react'
-import faunadb from 'faunadb'
+import faunadb, { query as q } from 'faunadb'
 
 import { DataItem } from './types/fauna'
-import { FaunaStatus } from './constants'
+import { FaunaSchema, FaunaStatus } from './constants'
+
+function createQuery(
+  schema: string,
+  client: faunadb.Client,
+  scope: string
+): null | Promise<DataItem> {
+  switch (schema) {
+    case FaunaSchema.Collection:
+      return client.query(q.Get(q.Collection(scope)))
+    case FaunaSchema.Database:
+      return client.query(q.Get(q.Database(scope)))
+    case FaunaSchema.Document:
+      console.log('wants a document')
+      break
+    case FaunaSchema.Function:
+      return client.query(q.Get(q.Function(scope)))
+    case FaunaSchema.Index:
+      return client.query(q.Get(q.Index(scope)))
+  }
+
+  return null
+}
 
 export default function useGet(client: faunadb.Client): [Function, null | DataItem, string] {
   console.log(client)
-  const [data] = useState(null)
-  const [status] = useState(FaunaStatus.NOT_LOADED)
-  const get = useCallback(() => {}, [])
+  const [data, setData] = useState<null | DataItem>(null)
+  const [status, setStatus] = useState(FaunaStatus.NOT_LOADED)
+
+  const get = useCallback((schema: string, scope: string) => {
+    const fqlQuery = createQuery(schema, client, scope)
+
+    if (fqlQuery) {
+      console.log('we have a query')
+      fqlQuery
+        .then((res: DataItem) => {
+          setStatus(FaunaStatus.LOADING)
+          setData(res)
+          setStatus(FaunaStatus.LOADED)
+        })
+        .catch(err => {
+          console.error(`[fauna-hooks] ${err}`)
+          setStatus(FaunaStatus.ERROR)
+        })
+    }
+  }, [])
 
   return [get, data, status]
 }

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -10,7 +10,6 @@ function createQuery(
   scope: string,
   refId: string = ''
 ): null | Promise<DataItem> {
-  console.log(refId)
   switch (schema) {
     case FaunaSchema.Collection:
       return client.query(q.Get(q.Collection(scope)))
@@ -28,7 +27,6 @@ function createQuery(
 }
 
 export default function useGet(client: faunadb.Client): [Function, null | DataItem, string] {
-  console.log(client)
   const [data, setData] = useState<null | DataItem>(null)
   const [status, setStatus] = useState(FaunaStatus.NOT_LOADED)
 
@@ -36,7 +34,6 @@ export default function useGet(client: faunadb.Client): [Function, null | DataIt
     const fqlQuery = createQuery(schema, client, scope, refId)
 
     if (fqlQuery) {
-      console.log('we have a query')
       fqlQuery
         .then((res: DataItem) => {
           setStatus(FaunaStatus.LOADING)

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -7,16 +7,17 @@ import { FaunaSchema, FaunaStatus } from './constants'
 function createQuery(
   schema: string,
   client: faunadb.Client,
-  scope: string
+  scope: string,
+  refId: string = ''
 ): null | Promise<DataItem> {
+  console.log(refId)
   switch (schema) {
     case FaunaSchema.Collection:
       return client.query(q.Get(q.Collection(scope)))
     case FaunaSchema.Database:
       return client.query(q.Get(q.Database(scope)))
     case FaunaSchema.Document:
-      console.log('wants a document')
-      break
+      return client.query(q.Get(q.Ref(q.Collection(scope), refId)))
     case FaunaSchema.Function:
       return client.query(q.Get(q.Function(scope)))
     case FaunaSchema.Index:
@@ -31,8 +32,8 @@ export default function useGet(client: faunadb.Client): [Function, null | DataIt
   const [data, setData] = useState<null | DataItem>(null)
   const [status, setStatus] = useState(FaunaStatus.NOT_LOADED)
 
-  const get = useCallback((schema: string, scope: string) => {
-    const fqlQuery = createQuery(schema, client, scope)
+  const get = useCallback((schema: string, scope: string, refId?: string) => {
+    const fqlQuery = createQuery(schema, client, scope, refId)
 
     if (fqlQuery) {
       console.log('we have a query')


### PR DESCRIPTION
This PR adds a general `useGet` hook which allows users to get a single schema item from the database (see list of schemas below).

```
// Current API
const client = useFaunaClient(FAUNA_SECRET)

const [get, data, status] = useGet(client)
get('collection', 'my-collection-name')
get('databas', 'my-database-name')
get('document', 'my-collection-name', '1234567890')
get('function', 'my-function-name')
get('index', 'my-index-name')
```

This hooks currently supports the following Fauna schemas:
- Collection
- Database
- Document
- Function
- Index
